### PR TITLE
Allow thermogenerator to use world temperature instead of lava

### DIFF
--- a/objects/wired/energy/thermogenerator/thermogenerator.object
+++ b/objects/wired/energy/thermogenerator/thermogenerator.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "thermogenerator",
   "rarity" : "Common",
-  "description" : "Connect to lava source and submerge in water to generate energy",
+  "description" : "Submerge in water to generate energy from world temperature. Connect to lava source to increase greatly energy generation.",
   "shortdescription" : "Thermoelectric Generator",
   "race" : "generic",
   "objectType" : "wire",


### PR DESCRIPTION
Hello,

I thinked about a way to generate electricity from world temperature. But there was already a thermogenerator. So I think, why not allow it to use world temperature instead of lava (while keeping water consumption), but with a lesser energy generation ?

This is what this PR do. If no lava source connected, it will start to generate 0.025 energy per degree (to be multiplied by 3 if fully immerged). This require a world with stricly more than 0 degree as temperature.

Let say the world is at 10 degrees and the thermogenerator fully immerged. It will generate 0.75 energy, while connecting it to lava would generate 6 energy. So we need 8 thermogenerator without lava to do the same than 1 thermogenerator with lava (if the world is at 10 degree).

This add a new funny (because it require water ^^) way to generate energy, and it also work in night (but temperature decrease during night !).
